### PR TITLE
Cancel in progress build if a new push arrives while in progress.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
       - "./mpv/**.lib" # Will hopefully soon be removed when I finally get to create the damn lib file in a CI
       - ".cargo/**"
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
       - ".cargo/**"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
A rare inevitability but might as well check it to not waste github resources if multiple commits come in at once.